### PR TITLE
Update deprecated use of /e modifier with preg_replace

### DIFF
--- a/src/CachedReverseProxy.php
+++ b/src/CachedReverseProxy.php
@@ -131,7 +131,8 @@ class CachedReverseProxy
         }
 
         foreach ($response->headers as $header) {
-            if (preg_match("#^HTTP/\S+\s+(\d\d\d)#i", $header, $matches)) {
+
+            if (preg_match_all("#^HTTP/\S+\s+(\d\d\d)#i", $header, $matches)) {
                 return $matches[1];
             }
         }
@@ -154,12 +155,18 @@ class CachedReverseProxy
         $retVal = array();
         $fields = explode("\r\n", preg_replace('/\x0D\x0A[\x09\x20]+/', ' ', $header));
         foreach ($fields as $field) {
-            if (preg_match('/([^:]+): (.+)/m', $field, $match)) {
-                $match[1] = preg_replace('/(?<=^|[\x09\x20\x2D])./e', 'strtoupper("\0")', strtolower(trim($match[1])));
-                if (isset($retVal[$match[1]])) {
-                    $retVal[$match[1]] = array($retVal[$match[1]], $match[2]);
+            if (preg_match_all('/([^:]+): (.+)/m', $field, $match)) {
+                $match[1][0] = preg_replace_callback(
+                    '/(?<=^|[\x09\x20\x2D])./',
+                    function ($matches) {
+                        return strtolower($matches[0]);
+                    },
+                    strtolower(trim($match[1][0]))
+                );
+                if (isset($retVal[$match[1][0]])) {
+                    $retVal[$match[1][0]] = array($retVal[$match[1][0]], $match[2][0]);
                 } else {
-                    $retVal[$match[1]] = trim($match[2]);
+                    $retVal[$match[1][0]] = trim($match[2][0]);
                 }
             }
         }


### PR DESCRIPTION
Change deprecated use of /e modifier with preg_replace by preg_replace_callback call, and use of preg_match_all instead of preg_match. This code is actually from Gui. Using the reverse proxy on a new project on php 5.6 we were getting errors.